### PR TITLE
bug/recursiveSmooshTwoBrands-call-stack-error

### DIFF
--- a/src/theme/helpers/getStylesByBrand.ts
+++ b/src/theme/helpers/getStylesByBrand.ts
@@ -6,10 +6,8 @@ export const recursiveSmooshTwoBrands = (obj1: StyleDefinition, obj2: StyleDefin
   const end: StyleDefinition = { ...obj1 };
   const obj2Entries = Object.entries(obj2)
 
-  let i = 0;
-  obj2Entries.forEach(([key, value]) => {
-    i++
-    if (i >= obj2Entries.length) return end
+  obj2Entries.forEach(([key, value], index) => {
+    if (obj2Entries.length > index) return end
     if (!value) {
       // special case for 0, null, and undefined since null would be type 'object'
       end[key] = value;

--- a/src/theme/helpers/getStylesByBrand.ts
+++ b/src/theme/helpers/getStylesByBrand.ts
@@ -16,8 +16,6 @@ export const recursiveSmooshTwoBrands = (obj1: StyleDefinition, obj2: StyleDefin
     } else if (simpleValueTypes.includes(typeof value)) {
       end[key] = value;
     } else if (typeof value === 'function') {
-      console.log(0, key, 1, value)
-      console.log(2, end[key])
       // @ts-ignore
       end[key] = theme => recursiveSmooshTwoBrands(
         // @ts-ignore

--- a/src/theme/helpers/getStylesByBrand.ts
+++ b/src/theme/helpers/getStylesByBrand.ts
@@ -4,13 +4,20 @@ export const recursiveSmooshTwoBrands = (obj1: StyleDefinition, obj2: StyleDefin
   // recursively map so that overrides smooshes into baseStyles
   const simpleValueTypes = ['string', 'number', 'boolean'];
   const end: StyleDefinition = { ...obj1 };
-  Object.entries(obj2).forEach(([key, value]) => {
+  const obj2Entries = Object.entries(obj2)
+
+  let i = 0;
+  obj2Entries.forEach(([key, value]) => {
+    i++
+    if (i >= obj2Entries.length) return end
     if (!value) {
       // special case for 0, null, and undefined since null would be type 'object'
       end[key] = value;
     } else if (simpleValueTypes.includes(typeof value)) {
       end[key] = value;
     } else if (typeof value === 'function') {
+      console.log(0, key, 1, value)
+      console.log(2, end[key])
       // @ts-ignore
       end[key] = theme => recursiveSmooshTwoBrands(
         // @ts-ignore


### PR DESCRIPTION
- adds a check if `recursiveSmooshTwoBrands` has iterated through every entry of object and returns 